### PR TITLE
Add comprehensive tests for contato and profissional flows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.3.4</version>
+                <relativePath/> <!-- lookup parent from repository -->
+        </parent>
 	<groupId>com.cadastro-profissionais</groupId>
 	<artifactId>api</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -29,7 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -55,12 +55,17 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>
@@ -78,41 +83,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
-
 </project>

--- a/src/test/java/com/cadastro/profissionais/api/application/service/ManageContatoServiceTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/application/service/ManageContatoServiceTest.java
@@ -1,0 +1,162 @@
+package com.cadastro.profissionais.api.application.service;
+
+import com.cadastro.profissionais.api.application.converter.ContatoConverter;
+import com.cadastro.profissionais.api.application.port.out.ContatoRepositoryPort;
+import com.cadastro.profissionais.api.application.port.out.ProfissionalRepositoryPort;
+import com.cadastro.profissionais.api.domain.Contato;
+import com.cadastro.profissionais.api.domain.Profissional;
+import com.cadastro.profissionais.api.domain.dto.ContatoRequestDTO;
+import com.cadastro.profissionais.api.domain.dto.ContatoResponseDTO;
+import com.cadastro.profissionais.api.domain.dto.ProfissionalDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageContatoServiceTest {
+
+    @Mock
+    private ContatoRepositoryPort contatoRepository;
+
+    @Mock
+    private ProfissionalRepositoryPort profissionalRepository;
+
+    @Mock
+    private ContatoConverter contatoConverter;
+
+    @InjectMocks
+    private ManageContatoService manageContatoService;
+
+    private Contato contato;
+    private Profissional profissional;
+
+    @BeforeEach
+    void setUp() {
+        profissional = new Profissional();
+        profissional.setId(5L);
+        profissional.setNome("John");
+
+        contato = new Contato();
+        contato.setId(1L);
+        contato.setNome("Telefone");
+        contato.setContato("123456");
+        contato.setProfissional(profissional);
+    }
+
+    @Test
+    void shouldReturnContatosWithFilterFields() {
+        ContatoResponseDTO dto = new ContatoResponseDTO();
+        dto.setId(1L);
+        dto.setNome("Telefone");
+
+        when(contatoRepository.findByQuery("tel")).thenReturn(List.of(contato));
+        when(contatoConverter.toDto(contato)).thenReturn(dto);
+
+        List<ContatoResponseDTO> responses = manageContatoService.getContatos("tel", List.of("id", "nome"));
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getNome()).isEqualTo("Telefone");
+        verify(contatoRepository).findByQuery("tel");
+    }
+
+    @Test
+    void shouldReturnContatoById() {
+        ContatoResponseDTO dto = new ContatoResponseDTO();
+        dto.setId(1L);
+        when(contatoRepository.findById(1L)).thenReturn(Optional.of(contato));
+        when(contatoConverter.toDto(contato)).thenReturn(dto);
+
+        Optional<ContatoResponseDTO> result = manageContatoService.getContatoById(1L);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldCreateContatoWhenNotDuplicate() {
+        ContatoRequestDTO requestDTO = new ContatoRequestDTO();
+        requestDTO.setNome("Telefone");
+        requestDTO.setContato("123456");
+        ProfissionalDTO profissionalDTO = new ProfissionalDTO();
+        profissionalDTO.setNome("John");
+        requestDTO.setProfissional(profissionalDTO);
+
+        when(profissionalRepository.findByNome("John")).thenReturn(profissional);
+        when(contatoRepository.findByNomeContatoProfissional(any(), any(), any())).thenReturn(List.of());
+        when(contatoConverter.toEntity(requestDTO, profissional)).thenReturn(contato);
+        when(contatoRepository.save(contato)).thenReturn(contato);
+
+        ResponseEntity<String> response = manageContatoService.createContato(requestDTO);
+
+        assertThat(response.getBody()).contains("Sucesso, contato com id 1 cadastrado");
+        verify(contatoRepository).save(contato);
+        assertThat(contato.getCreatedDate()).isInstanceOf(Date.class);
+    }
+
+    @Test
+    void shouldReturnDuplicateMessageWhenContatoExists() {
+        ContatoRequestDTO requestDTO = new ContatoRequestDTO();
+        when(contatoRepository.findByNomeContatoProfissional(any(), any(), any())).thenReturn(List.of(contato));
+
+        ResponseEntity<String> response = manageContatoService.createContato(requestDTO);
+
+        assertThat(response.getBody()).isEqualTo("Contato já está cadastrado.");
+        verify(contatoRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldUpdateExistingContato() {
+        ContatoRequestDTO requestDTO = new ContatoRequestDTO();
+        requestDTO.setNome("Email");
+
+        when(contatoRepository.findById(1L)).thenReturn(Optional.of(contato));
+        when(contatoRepository.save(contato)).thenReturn(contato);
+
+        ResponseEntity<String> response = manageContatoService.updateContato(1L, requestDTO);
+
+        assertThat(response.getBody()).isEqualTo("Sucesso, cadastro alterado");
+        verify(contatoConverter).updateEntity(contato, requestDTO);
+        verify(contatoRepository).save(contato);
+        assertThat(contato.getCreatedDate()).isInstanceOf(Date.class);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUpdatingNonExistingContato() {
+        when(contatoRepository.findById(2L)).thenReturn(Optional.empty());
+
+        ResponseEntity<String> response = manageContatoService.updateContato(2L, new ContatoRequestDTO());
+
+        assertThat(response.getStatusCode().is4xxClientError()).isTrue();
+    }
+
+    @Test
+    void shouldDeleteContatoWhenExists() {
+        when(contatoRepository.findById(1L)).thenReturn(Optional.of(contato));
+
+        ResponseEntity<String> response = manageContatoService.deleteContato(1L);
+
+        assertThat(response.getBody()).isEqualTo("Sucesso, contato excluído");
+        verify(contatoRepository).delete(contato);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenDeletingMissingContato() {
+        when(contatoRepository.findById(3L)).thenReturn(Optional.empty());
+
+        ResponseEntity<String> response = manageContatoService.deleteContato(3L);
+
+        assertThat(response.getStatusCode().is4xxClientError()).isTrue();
+    }
+}

--- a/src/test/java/com/cadastro/profissionais/api/application/service/ManageProfissionalServiceTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/application/service/ManageProfissionalServiceTest.java
@@ -1,0 +1,173 @@
+package com.cadastro.profissionais.api.application.service;
+
+import com.cadastro.profissionais.api.application.converter.ProfissionalConverter;
+import com.cadastro.profissionais.api.application.port.out.ProfissionalRepositoryPort;
+import com.cadastro.profissionais.api.domain.Profissional;
+import com.cadastro.profissionais.api.domain.dto.ProfissionalRequestDTO;
+import com.cadastro.profissionais.api.domain.dto.ProfissionalResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageProfissionalServiceTest {
+
+    @Mock
+    private ProfissionalRepositoryPort profissionalRepository;
+
+    @Mock
+    private ProfissionalConverter profissionalConverter;
+
+    @InjectMocks
+    private ManageProfissionalService manageProfissionalService;
+
+    private Profissional ativo;
+    private Profissional inativo;
+
+    @BeforeEach
+    void setUp() {
+        ativo = new Profissional();
+        ativo.setId(1L);
+        ativo.setNome("John Doe");
+        ativo.setCargo("Dev");
+        ativo.setAtivo(true);
+
+        inativo = new Profissional();
+        inativo.setId(2L);
+        inativo.setNome("Jane Doe");
+        inativo.setCargo("QA");
+        inativo.setAtivo(false);
+    }
+
+    @Test
+    void shouldReturnFilteredProfissionaisWhenQueryProvided() {
+        ProfissionalResponseDTO responseDTO = new ProfissionalResponseDTO();
+        responseDTO.setId(ativo.getId());
+        responseDTO.setNome(ativo.getNome());
+
+        when(profissionalRepository.findByQuery("doe")).thenReturn(Arrays.asList(ativo, inativo));
+        when(profissionalConverter.toResponseDto(ativo)).thenReturn(responseDTO);
+
+        List<ProfissionalResponseDTO> result = manageProfissionalService.getProfissionais("doe", List.of("id", "nome"));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(ativo.getId());
+        assertThat(result.get(0).getNome()).isEqualTo(ativo.getNome());
+        verify(profissionalRepository).findByQuery("doe");
+    }
+
+    @Test
+    void shouldReturnProfissionalByIdWhenActive() {
+        ProfissionalResponseDTO responseDTO = new ProfissionalResponseDTO();
+        responseDTO.setId(ativo.getId());
+
+        when(profissionalRepository.findById(1L)).thenReturn(Optional.of(ativo));
+        when(profissionalConverter.toResponseDto(ativo)).thenReturn(responseDTO);
+
+        Optional<ProfissionalResponseDTO> result = manageProfissionalService.getProfissionalById(1L);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenProfissionalInactive() {
+        when(profissionalRepository.findById(2L)).thenReturn(Optional.of(inativo));
+
+        Optional<ProfissionalResponseDTO> result = manageProfissionalService.getProfissionalById(2L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldCreateNewProfissionalWhenNotExists() {
+        ProfissionalRequestDTO requestDTO = new ProfissionalRequestDTO();
+        requestDTO.setNome("John Doe");
+        requestDTO.setCargo("Dev");
+
+        Profissional entity = new Profissional();
+        entity.setId(10L);
+
+        when(profissionalRepository.findByNomeCargoNascimento(any(), any(), any())).thenReturn(List.of());
+        when(profissionalConverter.toEntity(requestDTO)).thenReturn(entity);
+        when(profissionalRepository.save(entity)).thenReturn(entity);
+
+        ResponseEntity<String> response = manageProfissionalService.createProfissional(requestDTO);
+
+        assertThat(response.getBody()).contains("Sucesso, profissional com id 10 cadastrado");
+        ArgumentCaptor<Profissional> captor = ArgumentCaptor.forClass(Profissional.class);
+        verify(profissionalRepository).save(captor.capture());
+        assertThat(captor.getValue().getCreatedDate()).isNotNull();
+        assertThat(captor.getValue().getAtivo()).isTrue();
+    }
+
+    @Test
+    void shouldNotCreateProfissionalWhenDuplicate() {
+        ProfissionalRequestDTO requestDTO = new ProfissionalRequestDTO();
+        when(profissionalRepository.findByNomeCargoNascimento(any(), any(), any())).thenReturn(List.of(ativo));
+
+        ResponseEntity<String> response = manageProfissionalService.createProfissional(requestDTO);
+
+        assertThat(response.getBody()).isEqualTo("Contato já está cadastrado.");
+        verify(profissionalRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldUpdateExistingActiveProfissional() {
+        ProfissionalRequestDTO requestDTO = new ProfissionalRequestDTO();
+        requestDTO.setNome("Updated");
+
+        when(profissionalRepository.findById(1L)).thenReturn(Optional.of(ativo));
+        when(profissionalRepository.save(ativo)).thenReturn(ativo);
+
+        String response = manageProfissionalService.updateProfissional(1L, requestDTO);
+
+        assertThat(response).isEqualTo("Sucesso, cadastro alterado");
+        verify(profissionalConverter).updateEntity(ativo, requestDTO);
+        verify(profissionalRepository).save(ativo);
+        assertThat(ativo.getCreatedDate()).isInstanceOf(Date.class);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUpdatingMissingProfissional() {
+        when(profissionalRepository.findById(3L)).thenReturn(Optional.empty());
+
+        String response = manageProfissionalService.updateProfissional(3L, new ProfissionalRequestDTO());
+
+        assertThat(response).isEqualTo("Profissional não encontrado");
+    }
+
+    @Test
+    void shouldDeleteProfissionalWhenActive() {
+        when(profissionalRepository.findById(1L)).thenReturn(Optional.of(ativo));
+
+        String response = manageProfissionalService.deleteProfissional(1L);
+
+        assertThat(response).isEqualTo("Sucesso, profissional excluído");
+        verify(profissionalRepository).save(ativo);
+        assertThat(ativo.getAtivo()).isFalse();
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenDeletingMissingProfissional() {
+        when(profissionalRepository.findById(4L)).thenReturn(Optional.empty());
+
+        String response = manageProfissionalService.deleteProfissional(4L);
+
+        assertThat(response).isEqualTo("Profissional não encontrado");
+    }
+}

--- a/src/test/java/com/cadastro/profissionais/api/controller/ContatoControllerIntegrationTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/controller/ContatoControllerIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.cadastro.profissionais.api.controller;
+
+import com.cadastro.profissionais.api.application.port.in.ManageContatoUseCase;
+import com.cadastro.profissionais.api.domain.dto.ContatoRequestDTO;
+import com.cadastro.profissionais.api.domain.dto.ContatoResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ContatoController.class)
+class ContatoControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ManageContatoUseCase manageContatoUseCase;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldListContatos() throws Exception {
+        ContatoResponseDTO dto = new ContatoResponseDTO();
+        dto.setId(1L);
+        dto.setNome("Telefone");
+
+        Mockito.when(manageContatoUseCase.getContatos("tel", List.of("id"))).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/contatos?q=tel&fields=id"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L));
+    }
+
+    @Test
+    void shouldReturnContatoById() throws Exception {
+        ContatoResponseDTO dto = new ContatoResponseDTO();
+        dto.setId(2L);
+        Mockito.when(manageContatoUseCase.getContatoById(2L)).thenReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/contatos/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(2L));
+    }
+
+    @Test
+    void shouldReturnNotFoundForContato() throws Exception {
+        Mockito.when(manageContatoUseCase.getContatoById(7L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/contatos/7"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldCreateContato() throws Exception {
+        ContatoRequestDTO request = new ContatoRequestDTO();
+        request.setNome("Telefone");
+        Mockito.when(manageContatoUseCase.createContato(Mockito.any()))
+                .thenReturn(org.springframework.http.ResponseEntity.ok("created"));
+
+        mockMvc.perform(post("/contatos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("created"));
+    }
+
+    @Test
+    void shouldUpdateContato() throws Exception {
+        Mockito.when(manageContatoUseCase.updateContato(Mockito.eq(1L), Mockito.any()))
+                .thenReturn(org.springframework.http.ResponseEntity.ok("updated"));
+
+        mockMvc.perform(put("/contatos/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ContatoRequestDTO())))
+                .andExpect(status().isOk())
+                .andExpect(content().string("updated"));
+    }
+
+    @Test
+    void shouldDeleteContato() throws Exception {
+        Mockito.when(manageContatoUseCase.deleteContato(3L))
+                .thenReturn(org.springframework.http.ResponseEntity.ok("deleted"));
+
+        mockMvc.perform(delete("/contatos/3"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("deleted"));
+    }
+}

--- a/src/test/java/com/cadastro/profissionais/api/controller/ProfissionalControllerIntegrationTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/controller/ProfissionalControllerIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.cadastro.profissionais.api.controller;
+
+import com.cadastro.profissionais.api.application.port.in.ManageProfissionalUseCase;
+import com.cadastro.profissionais.api.domain.dto.ProfissionalRequestDTO;
+import com.cadastro.profissionais.api.domain.dto.ProfissionalResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ProfissionalController.class)
+class ProfissionalControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ManageProfissionalUseCase manageProfissionalUseCase;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldListProfissionaisWithQueryParams() throws Exception {
+        ProfissionalResponseDTO responseDTO = new ProfissionalResponseDTO();
+        responseDTO.setId(1L);
+        responseDTO.setNome("John Doe");
+
+        Mockito.when(manageProfissionalUseCase.getProfissionais("doe", List.of("id")))
+                .thenReturn(List.of(responseDTO));
+
+        MvcResult result = mockMvc.perform(get("/profissionais?q=doe&fields=id"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("John Doe");
+    }
+
+    @Test
+    void shouldReturnProfissionalById() throws Exception {
+        ProfissionalResponseDTO responseDTO = new ProfissionalResponseDTO();
+        responseDTO.setId(1L);
+        Mockito.when(manageProfissionalUseCase.getProfissionalById(1L)).thenReturn(Optional.of(responseDTO));
+
+        mockMvc.perform(get("/profissionais/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenProfissionalMissing() throws Exception {
+        Mockito.when(manageProfissionalUseCase.getProfissionalById(9L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/profissionais/9"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldCreateProfissional() throws Exception {
+        ProfissionalRequestDTO request = new ProfissionalRequestDTO();
+        request.setNome("Jane");
+        Mockito.when(manageProfissionalUseCase.createProfissional(any()))
+                .thenReturn(org.springframework.http.ResponseEntity.ok("created"));
+
+        mockMvc.perform(post("/profissionais")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("created"));
+    }
+
+    @Test
+    void shouldUpdateProfissional() throws Exception {
+        Mockito.when(manageProfissionalUseCase.updateProfissional(any(), any())).thenReturn("updated");
+
+        mockMvc.perform(put("/profissionais/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ProfissionalRequestDTO())))
+                .andExpect(status().isOk())
+                .andExpect(content().string("updated"));
+    }
+
+    @Test
+    void shouldDeleteProfissional() throws Exception {
+        Mockito.when(manageProfissionalUseCase.deleteProfissional(1L)).thenReturn("deleted");
+
+        mockMvc.perform(delete("/profissionais/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("deleted"));
+    }
+}

--- a/src/test/java/com/cadastro/profissionais/api/infrastructure/persistence/jpa/ContatoJpaRepositoryTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/infrastructure/persistence/jpa/ContatoJpaRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.cadastro.profissionais.api.infrastructure.persistence.jpa;
+
+import com.cadastro.profissionais.api.domain.Contato;
+import com.cadastro.profissionais.api.domain.Profissional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ContatoJpaRepositoryTest {
+
+    @Autowired
+    private ContatoJpaRepository contatoJpaRepository;
+
+    @Autowired
+    private ProfissionalJpaRepository profissionalJpaRepository;
+
+    @Test
+    void shouldSearchContatoByQueryAndProfissional() {
+        Profissional profissional = new Profissional();
+        profissional.setNome("Joana");
+        profissional.setCargo("Dev");
+        profissional.setNascimento(new Date());
+        profissional.setAtivo(true);
+        profissionalJpaRepository.save(profissional);
+
+        Contato contato = new Contato();
+        contato.setNome("Whatsapp");
+        contato.setContato("9999-9999");
+        contato.setCreatedDate(new Date());
+        contato.setProfissional(profissional);
+        contatoJpaRepository.save(contato);
+
+        List<Contato> byQuery = contatoJpaRepository.findByQuery("What");
+        assertThat(byQuery).hasSize(1);
+
+        List<Contato> byNomeContatoProfissional = contatoJpaRepository
+                .findContatoByNomeAndContatoAndProfissional("Whatsapp", "9999-9999", profissional);
+        assertThat(byNomeContatoProfissional).hasSize(1);
+        assertThat(byNomeContatoProfissional.get(0).getProfissional().getNome()).isEqualTo("Joana");
+    }
+}

--- a/src/test/java/com/cadastro/profissionais/api/infrastructure/persistence/jpa/ProfissionalJpaRepositoryTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/infrastructure/persistence/jpa/ProfissionalJpaRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.cadastro.profissionais.api.infrastructure.persistence.jpa;
+
+import com.cadastro.profissionais.api.domain.Profissional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ProfissionalJpaRepositoryTest {
+
+    @Autowired
+    private ProfissionalJpaRepository profissionalJpaRepository;
+
+    @Test
+    void shouldFindByQueryAndByNomeCargoNascimento() {
+        Profissional profissional = new Profissional();
+        profissional.setNome("Maria");
+        profissional.setCargo("Engenheira");
+        profissional.setNascimento(new Date());
+        profissional.setAtivo(true);
+
+        profissionalJpaRepository.save(profissional);
+
+        List<Profissional> byQuery = profissionalJpaRepository.findByQuery("Maria");
+        assertThat(byQuery).hasSize(1);
+
+        List<Profissional> byNomeCargoNascimento = profissionalJpaRepository
+                .findProfissionalByNomeAndCargoAndNascimento("Maria", "Engenheira", profissional.getNascimento());
+        assertThat(byNomeCargoNascimento).hasSize(1);
+    }
+
+    @Test
+    void shouldFindByNome() {
+        Profissional profissional = new Profissional();
+        profissional.setNome("Carlos");
+        profissional.setCargo("Analista");
+        profissional.setNascimento(new Date());
+        profissional.setAtivo(true);
+
+        profissionalJpaRepository.save(profissional);
+
+        Profissional found = profissionalJpaRepository.findByNome("Carlos");
+        assertThat(found).isNotNull();
+        assertThat(found.getCargo()).isEqualTo("Analista");
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
## Summary
- add unit tests for contato and profissional service logic
- add controller integration tests covering all REST endpoints
- add JPA component tests with in-memory database configuration and H2 dependency
- switch to stable Spring Boot parent to allow local test execution

## Testing
- mvn test *(fails in CI environment due to inability to download Spring Boot parent from Maven Central; network returned HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693471e2d9988326a1c3638367d0139e)