### PR TITLE
Add request validation and error handling for profissional and contato

### DIFF
--- a/src/main/java/com/cadastro/profissionais/api/application/converter/ContatoConverter.java
+++ b/src/main/java/com/cadastro/profissionais/api/application/converter/ContatoConverter.java
@@ -6,6 +6,10 @@ import com.cadastro.profissionais.api.domain.dto.ContatoRequestDTO;
 import com.cadastro.profissionais.api.domain.dto.ContatoResponseDTO;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class ContatoConverter {
 
@@ -35,6 +39,16 @@ public class ContatoConverter {
         contato.setContato(dto.getContato());
         contato.setProfissional(profissional);
         return contato;
+    }
+
+    public List<Contato> toEntities(List<ContatoRequestDTO> dtos, Profissional profissional) {
+        if (dtos == null) {
+            return Collections.emptyList();
+        }
+
+        return dtos.stream()
+                .map(dto -> toEntity(dto, profissional))
+                .collect(Collectors.toList());
     }
 
     public void updateEntity(Contato contato, ContatoRequestDTO dto) {

--- a/src/main/java/com/cadastro/profissionais/api/application/converter/ProfissionalConverter.java
+++ b/src/main/java/com/cadastro/profissionais/api/application/converter/ProfissionalConverter.java
@@ -38,7 +38,6 @@ public class ProfissionalConverter {
         profissional.setCargo(dto.getCargo());
         profissional.setNascimento(dto.getNascimento());
         profissional.setAtivo(true);
-        profissional.setContatos(dto.getContatos());
         return profissional;
     }
 

--- a/src/main/java/com/cadastro/profissionais/api/application/service/ManageProfissionalService.java
+++ b/src/main/java/com/cadastro/profissionais/api/application/service/ManageProfissionalService.java
@@ -1,9 +1,11 @@
 package com.cadastro.profissionais.api.application.service;
 
 import com.cadastro.profissionais.api.application.converter.ProfissionalConverter;
+import com.cadastro.profissionais.api.application.converter.ContatoConverter;
 import com.cadastro.profissionais.api.application.port.in.ManageProfissionalUseCase;
 import com.cadastro.profissionais.api.application.port.out.ProfissionalRepositoryPort;
 import com.cadastro.profissionais.api.domain.Profissional;
+import com.cadastro.profissionais.api.domain.Contato;
 import com.cadastro.profissionais.api.domain.dto.ProfissionalRequestDTO;
 import com.cadastro.profissionais.api.domain.dto.ProfissionalResponseDTO;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +21,14 @@ public class ManageProfissionalService implements ManageProfissionalUseCase {
 
     private final ProfissionalRepositoryPort profissionalRepository;
     private final ProfissionalConverter profissionalConverter;
+    private final ContatoConverter contatoConverter;
 
     public ManageProfissionalService(ProfissionalRepositoryPort profissionalRepository,
-                                     ProfissionalConverter profissionalConverter) {
+                                     ProfissionalConverter profissionalConverter,
+                                     ContatoConverter contatoConverter) {
         this.profissionalRepository = profissionalRepository;
         this.profissionalConverter = profissionalConverter;
+        this.contatoConverter = contatoConverter;
     }
 
     @Override
@@ -53,6 +58,8 @@ public class ManageProfissionalService implements ManageProfissionalUseCase {
         if (profissionalDB.isEmpty()) {
             Profissional profissional = profissionalConverter.toEntity(profissionalRequest);
             profissional.setCreatedDate(new Date());
+            List<Contato> contatos = contatoConverter.toEntities(profissionalRequest.getContatos(), profissional);
+            profissional.setContatos(contatos);
             profissionalRepository.save(profissional);
             return ResponseEntity.ok("Sucesso, profissional com id " + profissional.getId() + " cadastrado");
         }

--- a/src/main/java/com/cadastro/profissionais/api/controller/ContatoController.java
+++ b/src/main/java/com/cadastro/profissionais/api/controller/ContatoController.java
@@ -3,6 +3,7 @@ package com.cadastro.profissionais.api.controller;
 import com.cadastro.profissionais.api.application.port.in.ManageContatoUseCase;
 import com.cadastro.profissionais.api.domain.dto.ContatoRequestDTO;
 import com.cadastro.profissionais.api.domain.dto.ContatoResponseDTO;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,12 +36,12 @@ public class ContatoController {
     }
 
     @PostMapping
-    public ResponseEntity<String> createContato(@RequestBody ContatoRequestDTO contatoRequest) {
+    public ResponseEntity<String> createContato(@Valid @RequestBody ContatoRequestDTO contatoRequest) {
         return contatoUseCase.createContato(contatoRequest);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<String> updateContato(@PathVariable Long id, @RequestBody ContatoRequestDTO contatoRequest) {
+    public ResponseEntity<String> updateContato(@PathVariable Long id, @Valid @RequestBody ContatoRequestDTO contatoRequest) {
         return contatoUseCase.updateContato(id, contatoRequest);
     }
 

--- a/src/main/java/com/cadastro/profissionais/api/controller/ProfissionalController.java
+++ b/src/main/java/com/cadastro/profissionais/api/controller/ProfissionalController.java
@@ -3,6 +3,7 @@ package com.cadastro.profissionais.api.controller;
 import com.cadastro.profissionais.api.application.port.in.ManageProfissionalUseCase;
 import com.cadastro.profissionais.api.domain.dto.ProfissionalRequestDTO;
 import com.cadastro.profissionais.api.domain.dto.ProfissionalResponseDTO;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,12 +35,12 @@ public class ProfissionalController {
     }
 
     @PostMapping
-    public ResponseEntity<String> createProfissional(@RequestBody ProfissionalRequestDTO profissionalRequest) {
+    public ResponseEntity<String> createProfissional(@Valid @RequestBody ProfissionalRequestDTO profissionalRequest) {
         return profissionalUseCase.createProfissional(profissionalRequest);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<String> updateProfissional(@PathVariable Long id, @RequestBody ProfissionalRequestDTO profissionalRequest) {
+    public ResponseEntity<String> updateProfissional(@PathVariable Long id, @Valid @RequestBody ProfissionalRequestDTO profissionalRequest) {
         String result = profissionalUseCase.updateProfissional(id, profissionalRequest);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/cadastro/profissionais/api/controller/RestExceptionHandler.java
+++ b/src/main/java/com/cadastro/profissionais/api/controller/RestExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.cadastro.profissionais.api.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        List<Map<String, String>> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(this::toErrorEntry)
+                .collect(Collectors.toList());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("errors", errors);
+
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    private Map<String, String> toErrorEntry(FieldError error) {
+        Map<String, String> entry = new HashMap<>();
+        entry.put("field", error.getField());
+        entry.put("message", error.getDefaultMessage());
+        return entry;
+    }
+}

--- a/src/main/java/com/cadastro/profissionais/api/domain/dto/ContatoRequestDTO.java
+++ b/src/main/java/com/cadastro/profissionais/api/domain/dto/ContatoRequestDTO.java
@@ -1,20 +1,28 @@
 package com.cadastro.profissionais.api.domain.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Date;
 
 @Data
-@Getter
-@Setter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ContatoRequestDTO {
     private Long id;
+
+    @NotBlank(message = "Nome do contato é obrigatório")
+    @Size(max = 255, message = "Nome do contato deve ter no máximo 255 caracteres")
     private String nome;
+
+    @NotBlank(message = "Contato é obrigatório")
+    @Size(max = 255, message = "Contato deve ter no máximo 255 caracteres")
     private String contato;
+
     private Date createdDate;
+
+    @Valid
     private ProfissionalDTO profissional;
 }

--- a/src/main/java/com/cadastro/profissionais/api/domain/dto/ProfissionalRequestDTO.java
+++ b/src/main/java/com/cadastro/profissionais/api/domain/dto/ProfissionalRequestDTO.java
@@ -1,6 +1,9 @@
 package com.cadastro.profissionais.api.domain.dto;
 
-import com.cadastro.profissionais.api.domain.Contato;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
 import lombok.Data;
 
 import java.util.Date;
@@ -8,8 +11,16 @@ import java.util.List;
 
 @Data
 public class ProfissionalRequestDTO {
+    @NotBlank(message = "Nome é obrigatório")
     private String nome;
+
+    @NotBlank(message = "Cargo é obrigatório")
     private String cargo;
+
+    @NotNull(message = "Data de nascimento é obrigatória")
+    @Past(message = "Data de nascimento deve estar no passado")
     private Date nascimento;
-    private List<Contato> contatos;
+
+    @Valid
+    private List<ContatoRequestDTO> contatos;
 }

--- a/src/test/java/com/cadastro/profissionais/api/application/service/ManageProfissionalServiceTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/application/service/ManageProfissionalServiceTest.java
@@ -1,6 +1,7 @@
 package com.cadastro.profissionais.api.application.service;
 
 import com.cadastro.profissionais.api.application.converter.ProfissionalConverter;
+import com.cadastro.profissionais.api.application.converter.ContatoConverter;
 import com.cadastro.profissionais.api.application.port.out.ProfissionalRepositoryPort;
 import com.cadastro.profissionais.api.domain.Profissional;
 import com.cadastro.profissionais.api.domain.dto.ProfissionalRequestDTO;
@@ -31,6 +32,9 @@ class ManageProfissionalServiceTest {
 
     @Mock
     private ProfissionalConverter profissionalConverter;
+
+    @Mock
+    private ContatoConverter contatoConverter;
 
     @InjectMocks
     private ManageProfissionalService manageProfissionalService;
@@ -104,6 +108,7 @@ class ManageProfissionalServiceTest {
 
         when(profissionalRepository.findByNomeCargoNascimento(any(), any(), any())).thenReturn(List.of());
         when(profissionalConverter.toEntity(requestDTO)).thenReturn(entity);
+        when(contatoConverter.toEntities(any(), any())).thenReturn(List.of());
         when(profissionalRepository.save(entity)).thenReturn(entity);
 
         ResponseEntity<String> response = manageProfissionalService.createProfissional(requestDTO);

--- a/src/test/java/com/cadastro/profissionais/api/controller/ContatoControllerIntegrationTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/controller/ContatoControllerIntegrationTest.java
@@ -66,6 +66,7 @@ class ContatoControllerIntegrationTest {
     void shouldCreateContato() throws Exception {
         ContatoRequestDTO request = new ContatoRequestDTO();
         request.setNome("Telefone");
+        request.setContato("123456789");
         Mockito.when(manageContatoUseCase.createContato(Mockito.any()))
                 .thenReturn(org.springframework.http.ResponseEntity.ok("created"));
 
@@ -81,11 +82,27 @@ class ContatoControllerIntegrationTest {
         Mockito.when(manageContatoUseCase.updateContato(Mockito.eq(1L), Mockito.any()))
                 .thenReturn(org.springframework.http.ResponseEntity.ok("updated"));
 
+        ContatoRequestDTO request = new ContatoRequestDTO();
+        request.setNome("Telefone");
+        request.setContato("123456789");
+
         mockMvc.perform(put("/contatos/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new ContatoRequestDTO())))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("updated"));
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidContatoPayload() throws Exception {
+        ContatoRequestDTO invalidRequest = new ContatoRequestDTO();
+        invalidRequest.setContato("123456789");
+
+        mockMvc.perform(post("/contatos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0].field").value("nome"));
     }
 
     @Test

--- a/src/test/java/com/cadastro/profissionais/api/controller/ProfissionalControllerIntegrationTest.java
+++ b/src/test/java/com/cadastro/profissionais/api/controller/ProfissionalControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,6 +74,8 @@ class ProfissionalControllerIntegrationTest {
     void shouldCreateProfissional() throws Exception {
         ProfissionalRequestDTO request = new ProfissionalRequestDTO();
         request.setNome("Jane");
+        request.setCargo("Dev");
+        request.setNascimento(new Date(0));
         Mockito.when(manageProfissionalUseCase.createProfissional(any()))
                 .thenReturn(org.springframework.http.ResponseEntity.ok("created"));
 
@@ -87,11 +90,28 @@ class ProfissionalControllerIntegrationTest {
     void shouldUpdateProfissional() throws Exception {
         Mockito.when(manageProfissionalUseCase.updateProfissional(any(), any())).thenReturn("updated");
 
+        ProfissionalRequestDTO request = new ProfissionalRequestDTO();
+        request.setNome("Jane");
+        request.setCargo("Dev");
+        request.setNascimento(new Date(0));
+
         mockMvc.perform(put("/profissionais/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new ProfissionalRequestDTO())))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("updated"));
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidProfissionalPayload() throws Exception {
+        ProfissionalRequestDTO invalidRequest = new ProfissionalRequestDTO();
+        invalidRequest.setCargo("Dev");
+
+        mockMvc.perform(post("/profissionais")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0].field").value("nome"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add validation annotations to request DTOs and validate controller payloads
- provide global handler for structured validation errors
- update converters, services, and tests to use validated DTOs and cover invalid payloads

## Testing
- mvn test *(fails: repository access to maven central forbidden in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693590ce92cc8326be771d345a2daba5)